### PR TITLE
Read keys from pbf

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 
 * The arguments passed to `oe_read()` via `...` are compared to the formals of `st_read.character` and `st_as_sf.data.frame`. 
 * Added a new method to `oe_match` for `bbox` objects (#185).
+* The `oe_get_keys()` functio can be applied to `.osm.pbf` data (#188). 
 
 ### DOCUMENTATION FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 * The arguments passed to `oe_read()` via `...` are compared to the formals of `st_read.character` and `st_as_sf.data.frame`. 
 * Added a new method to `oe_match` for `bbox` objects (#185).
-* The `oe_get_keys()` functio can be applied to `.osm.pbf` data (#188). 
+* The `oe_get_keys()` function can be applied to `.osm.pbf` objects (#188). 
 
 ### DOCUMENTATION FIXES
 

--- a/R/vectortranslate.R
+++ b/R/vectortranslate.R
@@ -416,12 +416,20 @@ get_ini_layer_defaults = function(layer) {
 #' @export
 #'
 #' @examples
+#' # Get keys from pbf file
+#' itsleeds_pbf_path = oe_download(
+#'   oe_match("ITS Leeds")$url,
+#'   download_directory = tempdir(),
+#'   provider = "test"
+#' )
+#' oe_get_keys(itsleeds_pbf_path)
 #' itsleeds_gpkg_path = oe_get(
 #'   "ITS Leeds",
 #'   download_only = TRUE,
 #'   download_directory = tempdir(),
 #'   quiet = TRUE
 #' )
+#' itsleeds_gpkg_path
 #' oe_get_keys(itsleeds_gpkg_path)
 #'
 #' itsleeds = oe_get("ITS Leeds", quiet = TRUE, download_directory = tempdir())

--- a/data-raw/geofabrik_zones.R
+++ b/data-raw/geofabrik_zones.R
@@ -62,17 +62,17 @@ geofabrik_zones = st_sf(data.frame(geofabrik_zones, geofabrik_urls))
 # in bytes). We can get this information from the headers of each file.
 # Idea from:
 # https://stackoverflow.com/questions/2301009/get-file-size-before-downloading-counting-how-much-already-downloaded-httpru/2301030
-geofabrik_zones[["pbf_file_size"]] <- 0
+geofabrik_zones[["pbf_file_size"]] = 0
 
 ###############################################################################
 ###### RUN THE FOLLOWING CODE CAREFULLY SINCE IT CREATES HUNDREDS OF HEAD #####
 ###### REQUESTS THAT CAN BLOCK YOUR IP ADDRESS ################################
 ###############################################################################
 
-my_pb <- txtProgressBar(min = 0, max = nrow(geofabrik_zones), style = 3)
+my_pb = txtProgressBar(min = 0, max = nrow(geofabrik_zones), style = 3)
 for (i in seq_len(nrow(geofabrik_zones))) {
-  my_ith_url <- geofabrik_zones[["pbf"]][[i]]
-  geofabrik_zones[["pbf_file_size"]][[i]] <- as.numeric(headers(HEAD(my_ith_url))$`content-length`)
+  my_ith_url = geofabrik_zones[["pbf"]][[i]]
+  geofabrik_zones[["pbf_file_size"]][[i]] = as.numeric(headers(HEAD(my_ith_url))$`content-length`)
   setTxtProgressBar(my_pb, i)
 }
 

--- a/man/oe_get_keys.Rd
+++ b/man/oe_get_keys.Rd
@@ -16,10 +16,9 @@ oe_get_keys(zone, layer = "lines")
 \method{oe_get_keys}{sf}(zone, layer = "lines")
 }
 \arguments{
-\item{zone}{An \code{sf} object (typically read-in with \code{oe_read()} or \code{oe_get()})
-with an \code{other_tags} field, or a character vector (of length 1) that points
-to a \code{.gpkg} file (typically created using \code{oe_vectortranslate()} or
-\code{oe_get()}).}
+\item{zone}{An \code{sf} object with an \code{other_tags} field, or a character vector
+(of length 1) that points to a \code{.osm.pbf} or \code{.gpkg} file with an
+\code{other_tags} field.}
 
 \item{layer}{Which \code{layer} should be read in? Typically \code{points}, \code{lines}
 (the default), \code{multilinestrings}, \code{multipolygons} or \code{other_relations}. If
@@ -33,24 +32,22 @@ A character vector indicating the name of all keys stored in
 "other_tags" field.
 }
 \description{
-This function is used to return the names of all keys that are stored in
-"other_tags" column since they were not explicitly included in the file. See
-Details.
+This function returns the names of all keys that are stored in \code{other_tags}
+column. See Details.
 }
 \details{
 OSM data are typically documented using several
-\href{https://wiki.openstreetmap.org/wiki/Tags}{\code{tags}}. A \code{tag} is a pair of
-two items, namely a \code{key} and a \code{value}. As we documented in
+\href{https://wiki.openstreetmap.org/wiki/Tags}{\code{tags}}, i.e. pairs of two
+items, namely a \code{key} and a \code{value}. As documented in
 \code{\link[=oe_vectortranslate]{oe_vectortranslate()}}, the conversion between \code{.osm.pbf} and \code{.gpkg}
-formats is governed by a CONFIG file that indicates which tags are
-explicitly added to the \code{.gpkg} file. All the other keys stored in the
-\code{.osm.pbf} file are automatically appended using an "other_tags" field,
-with a syntax compatible with the PostgreSQL HSTORE type. This function is
-used to display the names of all keys stored in the "other_tags"
-column.
+formats is governed by a \code{CONFIG} file that lists which tags must be
+explicitly added to the \code{.gpkg} file, while all the other keys are
+automatically stored using an \code{other_tags} field with a syntax compatible
+with the PostgreSQL HSTORE type. This function can be used to display the
+names of all keys stored in the \code{other_tags} field.
 
-You can also use the \code{hstore_get_value()} function from GDAL to extract one
-particular tag from an existing \code{.gpkg} file. Check the introductory
+The \code{hstore_get_value()} function can be used inside the \code{query} argument
+to extract one particular tag from an existing file. Check the introductory
 vignette and see examples.
 
 The definition of a generic S3 implementation started in

--- a/man/oe_get_keys.Rd
+++ b/man/oe_get_keys.Rd
@@ -54,12 +54,20 @@ The definition of a generic S3 implementation started in
 \href{https://github.com/ropensci/osmextract/issues/138}{osmextract/issues/138}.
 }
 \examples{
+# Get keys from pbf file
+itsleeds_pbf_path = oe_download(
+  oe_match("ITS Leeds")$url,
+  download_directory = tempdir(),
+  provider = "test"
+)
+oe_get_keys(itsleeds_pbf_path)
 itsleeds_gpkg_path = oe_get(
   "ITS Leeds",
   download_only = TRUE,
   download_directory = tempdir(),
   quiet = TRUE
 )
+itsleeds_gpkg_path
 oe_get_keys(itsleeds_gpkg_path)
 
 itsleeds = oe_get("ITS Leeds", quiet = TRUE, download_directory = tempdir())

--- a/my-rhub-commands.R
+++ b/my-rhub-commands.R
@@ -1,6 +1,6 @@
 library(rhub)
 
-# results <- check_for_cran(
+# results = check_for_cran(
 #   platforms = c(
 #     "ubuntu-gcc-release",
 #     "windows-x86_64-devel",
@@ -9,9 +9,9 @@ library(rhub)
 #   show_status = FALSE
 # )
 #
-# previous_checks <- rhub::list_package_checks(howmany = 1)
-# id <- previous_checks$group[1]
-# group_check <- rhub::get_check(id)
+# previous_checks = rhub::list_package_checks(howmany = 1)
+# id = previous_checks$group[1]
+# group_check = rhub::get_check(id)
 # group_check
 #
 # group_check$cran_summary()

--- a/tests/testthat/test-find.R
+++ b/tests/testthat/test-find.R
@@ -2,7 +2,7 @@ test_that("oe_find: simplest example works", {
   # Fill the tempdir
   oe_get("ITS Leeds", download_directory = tempdir(), quiet = TRUE)
 
-  its_leeds_find <- oe_find(
+  its_leeds_find = oe_find(
     "ITS Leeds",
     provider = "test",
     download_directory = tempdir(),
@@ -16,7 +16,7 @@ test_that("oe_find: simplest example works", {
 
 test_that("download_if_missing in oe_find works", {
   # Test download_if_missing
-  its_leeds_find <- oe_find(
+  its_leeds_find = oe_find(
     "ITS Leeds",
     provider = "test",
     download_directory = tempdir(),

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -12,7 +12,7 @@ test_that("vectortranslate is not skipped if force_download is TRUE", {
   # I need to download the following files in a new directory since they could
   # be mixed with previously downloaded files (and hence ruin the tests)
 
-  small_its_leeds <- oe_get(
+  small_its_leeds = oe_get(
     "ITS Leeds",
     download_directory = tempdir(),
     vectortranslate_options = c(
@@ -26,7 +26,7 @@ test_that("vectortranslate is not skipped if force_download is TRUE", {
   )
 
   # Download it again
-  its_leeds <- oe_get(
+  its_leeds = oe_get(
     "ITS Leeds",
     download_directory = tempdir(),
     force_vectortranslate = TRUE,

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -110,7 +110,7 @@ test_that("oe_match: error when input place is far from all zones and match_by !
 
 test_that("oe_match: test level parameter", {
   # See https://github.com/ropensci/osmextract/issues/160
-  yak <- c(-120.51084, 46.60156)
+  yak = c(-120.51084, 46.60156)
 
   expect_equal(
     oe_match(yak, level = 1)$url,
@@ -139,7 +139,7 @@ test_that("oe_match:sfc objects with multiple places", {
 
 test_that("oe_match works with a bbox in input", {
   # See https://github.com/ropensci/osmextract/issues/185
-  my_bbox <- sf::st_bbox(
+  my_bbox = sf::st_bbox(
     c(xmin = 11.23602, ymin = 47.80478, xmax = 11.88867, ymax = 48.24261),
     crs = 4326
   )
@@ -151,7 +151,7 @@ test_that("oe_match works with a bbox in input", {
 
 test_that("oe_match returns a warning message with missing CRS in input place", {
   # See https://github.com/ropensci/osmextract/issues/185#issuecomment-810378795
-  my_bbox <- sf::st_bbox(
+  my_bbox = sf::st_bbox(
     c(xmin = 11.23602, ymin = 47.80478, xmax = 11.88867, ymax = 48.24261)
   )
   expect_warning(

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -39,7 +39,18 @@ test_that("or_read: simplest example with a URL works", {
     NA
   )
 
-  # clean tempdir
+  # Clean tempdir. First I need to remove the .pbf file
+  file.remove(
+    oe_read(
+      my_url,
+      download_only = TRUE,
+      skip_vectortranslate = TRUE,
+      download_directory = tempdir(),
+      provider = "test",
+      quiet = TRUE
+    )
+  )
+  # and then the .gkg file
   file.remove(
     oe_read(
       my_url,

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -45,16 +45,8 @@ test_that("or_read: simplest example with a URL works", {
       my_url,
       download_only = TRUE,
       download_directory = tempdir(),
-      provider = "test"
-    )
-  )
-  file.remove(
-    oe_read(
-      my_url,
-      download_only = TRUE,
-      download_directory = tempdir(),
       provider = "test",
-      skip_vectortranslate = TRUE
+      quiet = TRUE
     )
   )
 })
@@ -95,7 +87,8 @@ test_that("oe_read returns a warning message when query != layer", {
       "ITS Leeds",
       layer = "points",
       query = "SELECT * FROM 'lines'",
-      download_directory = tempdir()
+      download_directory = tempdir(),
+      quiet = TRUE
     ),
     "The query selected a layer which is different from layer argument."
   )

--- a/tests/testthat/test-vectortranslate.R
+++ b/tests/testthat/test-vectortranslate.R
@@ -47,11 +47,20 @@ test_that("oe_vectortranslate adds new tags to existing file", {
   file.remove(new_its_gpkg)
 })
 
-test_that("oe_get_keys: simplest example works", {
-  itsleeds_gpkg = oe_vectortranslate(its_pbf, quiet = TRUE)
-  expect_type(oe_get_keys(itsleeds_gpkg), "character")
+test_that("oe_get_keys: simplest examples works", {
+  # Define path to gpkg object
+  its_gpkg = oe_vectortranslate(its_pbf, quiet = TRUE)
 
-  file.remove(itsleeds_gpkg)
+  # Extract keys from pbg and gpkg file
+  keys1 <- oe_get_keys(its_pbf)
+  keys2 <- oe_get_keys(its_gpkg)
+
+  # Tests
+  expect_type(keys1, "character")
+  expect_type(keys2, "character")
+  expect_equal(length(keys1), length(keys2))
+
+  file.remove(its_gpkg)
 })
 
 test_that("oe_get_keys: returns error with wrong inputs", {

--- a/tests/testthat/test-vectortranslate.R
+++ b/tests/testthat/test-vectortranslate.R
@@ -52,8 +52,8 @@ test_that("oe_get_keys: simplest examples works", {
   its_gpkg = oe_vectortranslate(its_pbf, quiet = TRUE)
 
   # Extract keys from pbg and gpkg file
-  keys1 <- oe_get_keys(its_pbf)
-  keys2 <- oe_get_keys(its_gpkg)
+  keys1 = oe_get_keys(its_pbf)
+  keys2 = oe_get_keys(its_gpkg)
 
   # Tests
   expect_type(keys1, "character")
@@ -69,7 +69,7 @@ test_that("oe_get_keys: returns error with wrong inputs", {
 
 test_that("oe_get_keys stop when there is no other_tags field", {
   # Read data ignoring the other_tags field
-  its <- oe_get(
+  its = oe_get(
     "ITS Leeds",
     download_directory = tempdir(),
     query = "SELECT highway, geometry FROM lines",
@@ -81,7 +81,7 @@ test_that("oe_get_keys stop when there is no other_tags field", {
   )
 
   # Translate data ignoring the other_tags field
-  its <- oe_get(
+  its = oe_get(
     "ITS Leeds",
     download_only = TRUE,
     download_directory = tempdir(),

--- a/tests/testthat/test-vectortranslate.R
+++ b/tests/testthat/test-vectortranslate.R
@@ -68,21 +68,33 @@ test_that("oe_get_keys: returns error with wrong inputs", {
 })
 
 test_that("oe_get_keys stop when there is no other_tags field", {
-  my_vectortranslate <- c(
-    "-f", "GPKG",
-    "-overwrite",
-    "-select", "highway",
-    "lines"
-  )
-  oe_get(
+  # Read data ignoring the other_tags field
+  its <- oe_get(
     "ITS Leeds",
-    vectortranslate_options = my_vectortranslate,
-    download_directory = tempdir()
+    download_directory = tempdir(),
+    query = "SELECT highway, geometry FROM lines",
+    quiet = TRUE
   )
-  its <- oe_get("ITS Leeds", download_only = TRUE, download_directory = tempdir())
+  expect_error(
+    oe_get_keys(its),
+    "The input object must have an other_tags field."
+  )
+
+  # Translate data ignoring the other_tags field
+  its <- oe_get(
+    "ITS Leeds",
+    download_only = TRUE,
+    download_directory = tempdir(),
+    quiet = TRUE,
+    vectortranslate_options = c(
+      "-f", "GPKG", "-overwrite", "-select", "highway", "lines"
+    )
+  )
   expect_error(
     oe_get_keys(its),
     "The input file must have an other_tags field."
   )
+
+  # Clean tempdir
   file.remove(oe_find("ITS Leeds", provider = "test", download_directory = tempdir()))
 })

--- a/tests/testthat/test-vectortranslate.R
+++ b/tests/testthat/test-vectortranslate.R
@@ -56,7 +56,6 @@ test_that("oe_get_keys: simplest example works", {
 
 test_that("oe_get_keys: returns error with wrong inputs", {
   expect_error(oe_get_keys("xxx.gpkg")) # file does not exist
-  expect_error(oe_get_keys(its_pbf)) # wrong format
 })
 
 test_that("oe_get_keys stop when there is no other_tags field", {

--- a/vignettes/providers_comparisons.Rmd
+++ b/vignettes/providers_comparisons.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 )
 
 # save user's pars
-user_par <- par(no.readonly = TRUE)
+user_par = par(no.readonly = TRUE)
 ```
 
 This vignette presents a simple comparison between the OSM providers supported by `osmextract`, explaining their pros and cons. 
@@ -114,8 +114,8 @@ plot(openstreetmap_fr_zones[openstreetmap_fr_zones$parent == "india", "name"], k
 France, 
 
 ```{r}
-ids_2 <- openstreetmap_fr_zones$parent %in% "france"
-ids_3 <- openstreetmap_fr_zones$parent %in% openstreetmap_fr_zones$id[ids_2]
+ids_2 = openstreetmap_fr_zones$parent %in% "france"
+ids_3 = openstreetmap_fr_zones$parent %in% openstreetmap_fr_zones$id[ids_2]
 
 plot(openstreetmap_fr_zones[ids_2 | ids_3, "name"], key.pos = NULL, main = NULL)
 ```
@@ -123,8 +123,8 @@ plot(openstreetmap_fr_zones[ids_2 | ids_3, "name"], key.pos = NULL, main = NULL)
 and Brazil
 
 ```{r}
-ids_2 <- openstreetmap_fr_zones$parent %in% "brazil"
-ids_3 <- openstreetmap_fr_zones$parent %in% openstreetmap_fr_zones$id[ids_2]
+ids_2 = openstreetmap_fr_zones$parent %in% "brazil"
+ids_3 = openstreetmap_fr_zones$parent %in% openstreetmap_fr_zones$id[ids_2]
 
 plot(openstreetmap_fr_zones[ids_2 | ids_3, "name"], key.pos = NULL, main = NULL)
 ```


### PR DESCRIPTION
Reprex: 

``` r
# packages
library(osmextract)
#> Data (c) OpenStreetMap contributors, ODbL 1.0. https://www.openstreetmap.org/copyright.
#> Check the package website, https://docs.ropensci.org/osmextract/, for more details.

# example
west_yorkshire <- oe_get("West Yorkshire", download_only = TRUE, skip_vectortranslate = TRUE)
#> The input place was matched with: West Yorkshire
#> The chosen file was already detected in the download directory. Skip downloading.

# read keys
head(oe_get_keys(west_yorkshire))
#> [1] "lit"           "addr:postcode" "lcn"           "maxspeed"     
#> [5] "sidewalk"      "oneway"
```

<sup>Created on 2021-04-06 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>
