### PR TITLE
Add boundary argument

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,4 +11,4 @@
 ^CRAN-RELEASE$
 my-rhub-commands.R
 pkgdown/
-notes.txt
+notes.R

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 .RData
 .Ruserdata
 inst/doc
-notes.txt
+notes.R

--- a/R/get.R
+++ b/R/get.R
@@ -138,6 +138,30 @@
 #' its_oneway = oe_get("ITS Leeds", query = q)
 #' its_oneway[, c(1, 3, 9)]
 #'
+#' # Apply a spatial filter during the vectortranslate operations
+#' its_poly = sf::st_sfc(
+#'   sf::st_polygon(
+#'     list(rbind(
+#'       c(-1.55577, 53.80850),
+#'       c(-1.55787, 53.80926),
+#'       c(-1.56096, 53.80891),
+#'       c(-1.56096, 53.80736),
+#'       c(-1.55675, 53.80658),
+#'       c(-1.55495, 53.80749),
+#'       c(-1.55577, 53.80850)
+#'     ))
+#'   ),
+#'   crs = 4326
+#' )
+#' its_spat = oe_get("ITS Leeds", boundary = its_poly)
+#' its_clipped = oe_get("ITS Leeds", boundary = its_poly, boundary_type = "clipsrc", quiet = TRUE)
+#'
+#' plot(sf::st_geometry(its), reset = FALSE, col = "lightgrey")
+#' plot(sf::st_boundary(its_poly), col = "black", add = TRUE)
+#' plot(sf::st_boundary(sf::st_as_sfc(sf::st_bbox(its_poly))), col = "black", add = TRUE)
+#' plot(sf::st_geometry(its_spat), add = TRUE, col = "darkred")
+#' plot(sf::st_geometry(its_clipped), add = TRUE, col = "orange")
+#'
 #' # More complex examples
 #' \dontrun{
 #'   west_yorkshire = oe_get("West Yorkshire")

--- a/R/get.R
+++ b/R/get.R
@@ -84,6 +84,14 @@
 #'   [0.9.6](https://r-spatial.github.io/sf/news/index.html#version-0-9-6-2020-09-13),
 #'    if `quiet` is equal to `FALSE`, then vectortranslate operations will
 #'   display a progress bar.
+#' @param boundary An `sf` or `sfc` object that will be used to create a spatial
+#'   filter during the vectortranslate operations. The type of filter can be
+#'   chosen using the argument `boundary_type`.
+#' @param boundary_type A character vector of length 1 specifying the type of
+#'   spatial filter. The `spat` filter selects only those features that
+#'   intersect a given area, while `clipsrc` also clips the geometries. See the
+#'   examples and check [here](https://gdal.org/programs/ogr2ogr.html) for more
+#'   details.
 #' @param download_only Boolean. If `TRUE`, then the function only returns the
 #'   path where the matched file is stored, instead of reading it. `FALSE` by
 #'   default.
@@ -173,6 +181,8 @@ oe_get = function(
   osmconf_ini = NULL,
   extra_tags = NULL,
   force_vectortranslate = FALSE,
+  boundary = NULL,
+  boundary_type = c("spat", "clipsrc"),
   download_only = FALSE,
   skip_vectortranslate = FALSE,
   never_skip_vectortranslate = FALSE,
@@ -217,6 +227,8 @@ oe_get = function(
     extra_tags = extra_tags,
     force_vectortranslate = force_vectortranslate,
     never_skip_vectortranslate = never_skip_vectortranslate,
+    boundary = boundary,
+    boundary_type = boundary_type,
     quiet = quiet,
     ...
   )

--- a/R/read.R
+++ b/R/read.R
@@ -88,6 +88,8 @@ oe_read = function(
   extra_tags = NULL,
   force_vectortranslate = FALSE,
   never_skip_vectortranslate = FALSE,
+  boundary = NULL,
+  boundary_type = c("spat", "clipsrc"),
   quiet = FALSE
 ) {
 
@@ -269,6 +271,8 @@ oe_read = function(
     extra_tags = extra_tags,
     force_vectortranslate = force_vectortranslate,
     never_skip_vectortranslate = never_skip_vectortranslate,
+    boundary = boundary,
+    boundary_type = boundary_type,
     quiet = quiet
   )
 

--- a/R/vectortranslate.R
+++ b/R/vectortranslate.R
@@ -2,18 +2,18 @@
 #'
 #' This function is used to translate a `.osm.pbf` file into `.gpkg` format.
 #' The conversion is performed using
-#' [ogr2ogr](https://gdal.org/programs/ogr2ogr.html#ogr2ogr) through
+#' [ogr2ogr](https://gdal.org/programs/ogr2ogr.html#ogr2ogr) via the
 #' `vectortranslate` utility in [sf::gdal_utils()] . It was created following
 #' [the
 #' suggestions](https://github.com/OSGeo/gdal/issues/2100#issuecomment-565707053)
-#' of the maintainers of GDAL. See Details and examples to understand the basic
+#' of the maintainers of GDAL. See Details and Examples to understand the basic
 #' usage, and check the introductory vignette for more complex use-cases.
 #'
 #' @details The new `.gpkg` file is created in the same directory as the input
 #'   `.osm.pbf` file. The translation process is performed using the
 #'   `vectortranslate` utility in [sf::gdal_utils()]. This operation can be
-#'   customized in several ways modifying the parameters `layer`,
-#'   `extra_tags`, `osmconf_ini`, and `vectortranslate_options`.
+#'   customized in several ways modifying the parameters `layer`, `extra_tags`,
+#'   `osmconf_ini`, `vectortranslate_options`, `boundary` and `boundary_type`.
 #'
 #'   The `.osm.pbf` files processed by GDAL are usually categorized into 5
 #'   layers, named `points`, `lines`, `multilinestrings`, `multipolygons` and
@@ -25,43 +25,47 @@
 #'   By default, the function will convert the `lines` layer (which is the most
 #'   common one according to our experience).
 #'
-#'   The arguments `osmconf_ini` and `extra_tags` are used to modify how
-#'   GDAL reads and processes a `.osm.pbf` file. More precisely, several operations
+#'   The arguments `osmconf_ini` and `extra_tags` are used to modify how GDAL
+#'   reads and processes a `.osm.pbf` file. More precisely, several operations
 #'   that GDAL performs on the input `.osm.pbf` file are governed by a `CONFIG`
-#'   file, that you can check at the following
+#'   file, that can be checked at the following
 #'   [link](https://github.com/OSGeo/gdal/blob/master/gdal/data/osmconf.ini).
 #'   The basic components of OSM data are called
 #'   [*elements*](https://wiki.openstreetmap.org/wiki/Elements) and they are
 #'   divided into *nodes*, *ways* or *relations*, so, for example, the code at
-#'   line 7 of that link is used to determine which *ways* are assumed to be polygons
-#'   (according to the simple-feature definition of polygon) if they are closed.
-#'   Moreover, OSM data is usually described using several
-#'   [*tags*](https://wiki.openstreetmap.org/wiki/Tags), i.e a pair of two
-#'   items: a key and a value. The code at lines 33, 53, 85, 103, and 121 is
-#'   used to determine, for each layer, which tags should be explicitly reported
-#'   as fields (while all the other tags are stored in the `other_tags` column,
-#'   see [oe_get_keys()]). The parameter `extra_tags` is used to determine
-#'   which extra tags (i.e. key/value pairs) should be added to the `.gpkg`
-#'   file.
+#'   line 7 of that file is used to determine which *ways* are assumed to be
+#'   polygons (according to the simple-feature definition of polygon) if they
+#'   are closed. Moreover, OSM data is usually described using several
+#'   [*tags*](https://wiki.openstreetmap.org/wiki/Tags), i.e pairs of two items:
+#'   a key and a value. The code at lines 33, 53, 85, 103, and 121 is used to
+#'   determine, for each layer, which tags should be explicitly reported as
+#'   fields (while all the other tags are stored in the `other_tags` column).
+#'   The parameter `extra_tags` is used to determine which extra tags (i.e.
+#'   key/value pairs) should be added to the `.gpkg` file (other than the
+#'   default ones).
 #'
 #'   By default, the vectortranslate operations are skipped if the function
-#'   detects a file having the same path as the input file, `.gpkg` extension
-#'   and a layer with the same name as the parameter `layer` with all
-#'   `extra_tags`. In that case the function will simply return the path of the
-#'   `.gpkg` file. This behaviour can be overwritten setting
-#'   `force_vectortranslate = TRUE`. The parameter `osmconf_ini` is used to pass
-#'   your own `CONFIG` file in case you need more control over the GDAL
-#'   operations. In that case the vectortranslate operations are never skipped.
-#'   Check the package introductory vignette for an example. If `osmconf_ini` is
-#'   equal to `NULL` (the default), then the function uses default `osmconf.ini`
-#'   file defined by GDAL (but for the extra tags).
+#'   detects a file having the same path as the input file, `.gpkg` extension, a
+#'   layer with the same name as the parameter `layer` and all `extra_tags`. In
+#'   that case the function will simply return the path of the `.gpkg` file.
+#'   This behaviour can be overwritten setting `force_vectortranslate = TRUE`.
+#'   The vectortranslate operations are never skipped if `osmconf_ini`,
+#'   `vectortranslate_options`, `boundary` or `boundary_type` arguments are not
+#'   `NULL`.
 #'
-#'   The parameter `vectortranslate_options` is used to control the arguments
-#'   that are passed to `ogr2ogr` via [sf::gdal_utils()] when converting between
-#'   `.pbf` and `.gpkg` formats. `ogr2ogr` can perform various operations during
-#'   the conversion process, such as spatial filters or SQL queries. These
-#'   operations are determined by the `vectortranslate_options` argument. If
-#'   `NULL` (the default value), then `vectortranslate_options` is set equal to
+#'   The parameter `osmconf_ini` is used to pass your own `CONFIG` file in case
+#'   you need more control over the GDAL operations. Check the package
+#'   introductory vignette for an example. If `osmconf_ini` is equal to `NULL`
+#'   (the default value), then the function uses the standard `osmconf.ini` file
+#'   defined by GDAL (but for the extra tags).
+#'
+#'   The parameter `vectortranslate_options` is used to control the options that
+#'   are passed to `ogr2ogr` via [sf::gdal_utils()] when converting between
+#'   `.osm.pbf` and `.gpkg` formats. `ogr2ogr` can perform various operations
+#'   during the conversion process, such as spatial filters or SQL queries.
+#'   These operations can be tuned using the `vectortranslate_options` argument.
+#'   If `NULL` (the default value), then `vectortranslate_options` is set equal
+#'   to
 #'
 #'   `c("-f", "GPKG", "-overwrite", "-oo", paste0("CONFIG_FILE=", osmconf_ini),
 #'   "-lco", "GEOMETRY_NAME=geometry", layer)`.
@@ -81,13 +85,24 @@
 #'
 #'   If `vectortranslate_options` is not `NULL`, then the options `c("-f",
 #'   "GPKG", "-overwrite", "-oo", "CONFIG_FILE=", path-to-config-file, "-lco",
-#'   "GEOMETRY_NAME=geometry")` are always appended at the end of the
-#'   `vectortranslate_options` unless the user explicitly sets different default
-#'   parameters for the arguments `-f`, `-oo` and `-lco`.
+#'   "GEOMETRY_NAME=geometry", layer)` are always appended unless the user
+#'   explicitly sets different default parameters for the arguments `-f`, `-oo`,
+#'   `-lco`, and `layer`.
 #'
-#'   Check the introductory vignette, the help page of [`sf::gdal_utils()`] and
-#'   [here](https://gdal.org/programs/ogr2ogr.html) for more examples and
-#'   extensive documentation on all available options.
+#'   The arguments `boundary` and `boundary_type` can be used to set up a
+#'   spatial filter during the vectortranslate operations (and speed up the
+#'   process) using an `sf` or `sfc` object (`POLYGON` or `MULTIPOLYGON`). The
+#'   default arguments create a rectangular spatial filter which selects all
+#'   features that intersect the area. Setting `boundary_type = "clipsrc"` clips
+#'   the geometries. In both cases, the appropriate options are automatically
+#'   added to the `vectortranslate_options` (unless a user explicitly sets
+#'   different default options). Check Examples in `oe_get()` and the
+#'   introductory vignette.
+#'
+#'   See also the help page of [`sf::gdal_utils()`] and
+#'   [ogr2ogr](https://gdal.org/programs/ogr2ogr.html) for more examples and
+#'   extensive documentation on all available options that can be tuned during
+#'   the vectortranslate process.
 #'
 #' @inheritParams oe_get
 #' @param file_path Character string representing the path of the input
@@ -336,10 +351,7 @@ oe_vectortranslate = function(
     # format_name)
     if ("-f" %!in% vectortranslate_options) {
       vectortranslate_options = c(vectortranslate_options, "-f", "GPKG")
-    }
-
-    # 1b. Check that the argument after "-f" is GPKG
-    if ("-f" %in% vectortranslate_options) {
+    } else {
       which_f = which(vectortranslate_options == "-f")
       if (
         which_f == length(vectortranslate_options) ||
@@ -471,7 +483,7 @@ get_ini_layer_defaults = function(layer) {
 
 process_boundary = function(
   vectortranslate_options,
-  boundary,
+  boundary = NULL,
   boundary_type = c("spat", "clipsrc")
 ) {
   # Checks
@@ -479,7 +491,7 @@ process_boundary = function(
     return(vectortranslate_options)
   }
 
-  if (any(c("-spat", "-clipsrc", "-nlt") %in% vectortranslate_options)) {
+  if (any(c("-spat", "-clipsrc") %in% vectortranslate_options)) {
     warning(
       "The boundary argument is ignored since the vectortraslate_options ",
       "already defines a spatial filter",

--- a/man/oe_get.Rd
+++ b/man/oe_get.Rd
@@ -184,6 +184,30 @@ q = "SELECT * FROM 'lines' WHERE oneway == 'yes'"
 its_oneway = oe_get("ITS Leeds", query = q)
 its_oneway[, c(1, 3, 9)]
 
+# Apply a spatial filter during the vectortranslate operations
+its_poly = sf::st_sfc(
+  sf::st_polygon(
+    list(rbind(
+      c(-1.55577, 53.80850),
+      c(-1.55787, 53.80926),
+      c(-1.56096, 53.80891),
+      c(-1.56096, 53.80736),
+      c(-1.55675, 53.80658),
+      c(-1.55495, 53.80749),
+      c(-1.55577, 53.80850)
+    ))
+  ),
+  crs = 4326
+)
+its_spat = oe_get("ITS Leeds", boundary = its_poly)
+its_clipped = oe_get("ITS Leeds", boundary = its_poly, boundary_type = "clipsrc", quiet = TRUE)
+
+plot(sf::st_geometry(its), reset = FALSE, col = "lightgrey")
+plot(sf::st_boundary(its_poly), col = "black", add = TRUE)
+plot(sf::st_boundary(sf::st_as_sfc(sf::st_bbox(its_poly))), col = "black", add = TRUE)
+plot(sf::st_geometry(its_spat), add = TRUE, col = "darkred")
+plot(sf::st_geometry(its_clipped), add = TRUE, col = "orange")
+
 # More complex examples
 \dontrun{
   west_yorkshire = oe_get("West Yorkshire")

--- a/man/oe_get.Rd
+++ b/man/oe_get.Rd
@@ -19,6 +19,8 @@ oe_get(
   osmconf_ini = NULL,
   extra_tags = NULL,
   force_vectortranslate = FALSE,
+  boundary = NULL,
+  boundary_type = c("spat", "clipsrc"),
   download_only = FALSE,
   skip_vectortranslate = FALSE,
   never_skip_vectortranslate = FALSE,
@@ -109,6 +111,16 @@ in previously translated \code{.gpkg} files no translation occurs
 (see \href{https://github.com/ropensci/osmextract/issues/173}{#173} for details).
 Check the introductory vignette and the help page of
 \code{\link[=oe_vectortranslate]{oe_vectortranslate()}}.}
+
+\item{boundary}{An \code{sf} or \code{sfc} object that will be used to create a spatial
+filter during the vectortranslate operations. The type of filter can be
+chosen using the argument \code{boundary_type}.}
+
+\item{boundary_type}{A character vector of length 1 specifying the type of
+spatial filter. The \code{spat} filter selects only those features that
+intersect a given area, while \code{clipsrc} also clips the geometries. See the
+examples and check \href{https://gdal.org/programs/ogr2ogr.html}{here} for more
+details.}
 
 \item{download_only}{Boolean. If \code{TRUE}, then the function only returns the
 path where the matched file is stored, instead of reading it. \code{FALSE} by

--- a/man/oe_read.Rd
+++ b/man/oe_read.Rd
@@ -20,6 +20,8 @@ oe_read(
   extra_tags = NULL,
   force_vectortranslate = FALSE,
   never_skip_vectortranslate = FALSE,
+  boundary = NULL,
+  boundary_type = c("spat", "clipsrc"),
   quiet = FALSE
 )
 }
@@ -97,6 +99,16 @@ Check the introductory vignette and the help page of
 passed its own \code{.ini} file or vectortranslate options (since, in those case,
 it's too difficult to determine if an existing \code{.gpkg} file was generated
 following the same options.)}
+
+\item{boundary}{An \code{sf} or \code{sfc} object that will be used to create a spatial
+filter during the vectortranslate operations. The type of filter can be
+chosen using the argument \code{boundary_type}.}
+
+\item{boundary_type}{A character vector of length 1 specifying the type of
+spatial filter. The \code{spat} filter selects only those features that
+intersect a given area, while \code{clipsrc} also clips the geometries. See the
+examples and check \href{https://gdal.org/programs/ogr2ogr.html}{here} for more
+details.}
 
 \item{quiet}{Boolean. If \code{FALSE}, the function prints informative messages.
 Starting from \code{sf} version

--- a/man/oe_vectortranslate.Rd
+++ b/man/oe_vectortranslate.Rd
@@ -77,18 +77,18 @@ Character string representing the path of the \code{.gpkg} file.
 \description{
 This function is used to translate a \code{.osm.pbf} file into \code{.gpkg} format.
 The conversion is performed using
-\href{https://gdal.org/programs/ogr2ogr.html#ogr2ogr}{ogr2ogr} through
+\href{https://gdal.org/programs/ogr2ogr.html#ogr2ogr}{ogr2ogr} via the
 \code{vectortranslate} utility in \code{\link[sf:gdal_utils]{sf::gdal_utils()}} . It was created following
 \href{https://github.com/OSGeo/gdal/issues/2100#issuecomment-565707053}{the suggestions}
-of the maintainers of GDAL. See Details and examples to understand the basic
+of the maintainers of GDAL. See Details and Examples to understand the basic
 usage, and check the introductory vignette for more complex use-cases.
 }
 \details{
 The new \code{.gpkg} file is created in the same directory as the input
 \code{.osm.pbf} file. The translation process is performed using the
 \code{vectortranslate} utility in \code{\link[sf:gdal_utils]{sf::gdal_utils()}}. This operation can be
-customized in several ways modifying the parameters \code{layer},
-\code{extra_tags}, \code{osmconf_ini}, and \code{vectortranslate_options}.
+customized in several ways modifying the parameters \code{layer}, \code{extra_tags},
+\code{osmconf_ini}, \code{vectortranslate_options}, \code{boundary} and \code{boundary_type}.
 
 The \code{.osm.pbf} files processed by GDAL are usually categorized into 5
 layers, named \code{points}, \code{lines}, \code{multilinestrings}, \code{multipolygons} and
@@ -100,43 +100,47 @@ Several layers with different names can be stored in the same \code{.gpkg} file.
 By default, the function will convert the \code{lines} layer (which is the most
 common one according to our experience).
 
-The arguments \code{osmconf_ini} and \code{extra_tags} are used to modify how
-GDAL reads and processes a \code{.osm.pbf} file. More precisely, several operations
+The arguments \code{osmconf_ini} and \code{extra_tags} are used to modify how GDAL
+reads and processes a \code{.osm.pbf} file. More precisely, several operations
 that GDAL performs on the input \code{.osm.pbf} file are governed by a \code{CONFIG}
-file, that you can check at the following
+file, that can be checked at the following
 \href{https://github.com/OSGeo/gdal/blob/master/gdal/data/osmconf.ini}{link}.
 The basic components of OSM data are called
 \href{https://wiki.openstreetmap.org/wiki/Elements}{\emph{elements}} and they are
 divided into \emph{nodes}, \emph{ways} or \emph{relations}, so, for example, the code at
-line 7 of that link is used to determine which \emph{ways} are assumed to be polygons
-(according to the simple-feature definition of polygon) if they are closed.
-Moreover, OSM data is usually described using several
-\href{https://wiki.openstreetmap.org/wiki/Tags}{\emph{tags}}, i.e a pair of two
-items: a key and a value. The code at lines 33, 53, 85, 103, and 121 is
-used to determine, for each layer, which tags should be explicitly reported
-as fields (while all the other tags are stored in the \code{other_tags} column,
-see \code{\link[=oe_get_keys]{oe_get_keys()}}). The parameter \code{extra_tags} is used to determine
-which extra tags (i.e. key/value pairs) should be added to the \code{.gpkg}
-file.
+line 7 of that file is used to determine which \emph{ways} are assumed to be
+polygons (according to the simple-feature definition of polygon) if they
+are closed. Moreover, OSM data is usually described using several
+\href{https://wiki.openstreetmap.org/wiki/Tags}{\emph{tags}}, i.e pairs of two items:
+a key and a value. The code at lines 33, 53, 85, 103, and 121 is used to
+determine, for each layer, which tags should be explicitly reported as
+fields (while all the other tags are stored in the \code{other_tags} column).
+The parameter \code{extra_tags} is used to determine which extra tags (i.e.
+key/value pairs) should be added to the \code{.gpkg} file (other than the
+default ones).
 
 By default, the vectortranslate operations are skipped if the function
-detects a file having the same path as the input file, \code{.gpkg} extension
-and a layer with the same name as the parameter \code{layer} with all
-\code{extra_tags}. In that case the function will simply return the path of the
-\code{.gpkg} file. This behaviour can be overwritten setting
-\code{force_vectortranslate = TRUE}. The parameter \code{osmconf_ini} is used to pass
-your own \code{CONFIG} file in case you need more control over the GDAL
-operations. In that case the vectortranslate operations are never skipped.
-Check the package introductory vignette for an example. If \code{osmconf_ini} is
-equal to \code{NULL} (the default), then the function uses default \code{osmconf.ini}
-file defined by GDAL (but for the extra tags).
+detects a file having the same path as the input file, \code{.gpkg} extension, a
+layer with the same name as the parameter \code{layer} and all \code{extra_tags}. In
+that case the function will simply return the path of the \code{.gpkg} file.
+This behaviour can be overwritten setting \code{force_vectortranslate = TRUE}.
+The vectortranslate operations are never skipped if \code{osmconf_ini},
+\code{vectortranslate_options}, \code{boundary} or \code{boundary_type} arguments are not
+\code{NULL}.
 
-The parameter \code{vectortranslate_options} is used to control the arguments
-that are passed to \code{ogr2ogr} via \code{\link[sf:gdal_utils]{sf::gdal_utils()}} when converting between
-\code{.pbf} and \code{.gpkg} formats. \code{ogr2ogr} can perform various operations during
-the conversion process, such as spatial filters or SQL queries. These
-operations are determined by the \code{vectortranslate_options} argument. If
-\code{NULL} (the default value), then \code{vectortranslate_options} is set equal to
+The parameter \code{osmconf_ini} is used to pass your own \code{CONFIG} file in case
+you need more control over the GDAL operations. Check the package
+introductory vignette for an example. If \code{osmconf_ini} is equal to \code{NULL}
+(the default value), then the function uses the standard \code{osmconf.ini} file
+defined by GDAL (but for the extra tags).
+
+The parameter \code{vectortranslate_options} is used to control the options that
+are passed to \code{ogr2ogr} via \code{\link[sf:gdal_utils]{sf::gdal_utils()}} when converting between
+\code{.osm.pbf} and \code{.gpkg} formats. \code{ogr2ogr} can perform various operations
+during the conversion process, such as spatial filters or SQL queries.
+These operations can be tuned using the \code{vectortranslate_options} argument.
+If \code{NULL} (the default value), then \code{vectortranslate_options} is set equal
+to
 
 \code{c("-f", "GPKG", "-overwrite", "-oo", paste0("CONFIG_FILE=", osmconf_ini), "-lco", "GEOMETRY_NAME=geometry", layer)}.
 
@@ -155,13 +159,24 @@ for the \code{.gpkg} file and modify the name of the geometry column;
 \item \code{layer} indicates which layer should be converted.
 }
 
-If \code{vectortranslate_options} is not \code{NULL}, then the options \code{c("-f", "GPKG", "-overwrite", "-oo", "CONFIG_FILE=", path-to-config-file, "-lco", "GEOMETRY_NAME=geometry")} are always appended at the end of the
-\code{vectortranslate_options} unless the user explicitly sets different default
-parameters for the arguments \code{-f}, \code{-oo} and \code{-lco}.
+If \code{vectortranslate_options} is not \code{NULL}, then the options \code{c("-f", "GPKG", "-overwrite", "-oo", "CONFIG_FILE=", path-to-config-file, "-lco", "GEOMETRY_NAME=geometry", layer)} are always appended unless the user
+explicitly sets different default parameters for the arguments \code{-f}, \code{-oo},
+\code{-lco}, and \code{layer}.
 
-Check the introductory vignette, the help page of \code{\link[sf:gdal_utils]{sf::gdal_utils()}} and
-\href{https://gdal.org/programs/ogr2ogr.html}{here} for more examples and
-extensive documentation on all available options.
+The arguments \code{boundary} and \code{boundary_type} can be used to set up a
+spatial filter during the vectortranslate operations (and speed up the
+process) using an \code{sf} or \code{sfc} object (\code{POLYGON} or \code{MULTIPOLYGON}). The
+default arguments create a rectangular spatial filter which selects all
+features that intersect the area. Setting \code{boundary_type = "clipsrc"} clips
+the geometries. In both cases, the appropriate options are automatically
+added to the \code{vectortranslate_options} (unless a user explicitly sets
+different default options). Check Examples in \code{oe_get()} and the
+introductory vignette.
+
+See also the help page of \code{\link[sf:gdal_utils]{sf::gdal_utils()}} and
+\href{https://gdal.org/programs/ogr2ogr.html}{ogr2ogr} for more examples and
+extensive documentation on all available options that can be tuned during
+the vectortranslate process.
 }
 \examples{
 # First we need to match an input zone with a .osm.pbf file

--- a/man/oe_vectortranslate.Rd
+++ b/man/oe_vectortranslate.Rd
@@ -12,6 +12,8 @@ oe_vectortranslate(
   extra_tags = NULL,
   force_vectortranslate = FALSE,
   never_skip_vectortranslate = FALSE,
+  boundary = NULL,
+  boundary_type = c("spat", "clipsrc"),
   quiet = FALSE
 )
 }
@@ -52,6 +54,16 @@ Check the introductory vignette and the help page of
 passed its own \code{.ini} file or vectortranslate options (since, in those case,
 it's too difficult to determine if an existing \code{.gpkg} file was generated
 following the same options.)}
+
+\item{boundary}{An \code{sf} or \code{sfc} object that will be used to create a spatial
+filter during the vectortranslate operations. The type of filter can be
+chosen using the argument \code{boundary_type}.}
+
+\item{boundary_type}{A character vector of length 1 specifying the type of
+spatial filter. The \code{spat} filter selects only those features that
+intersect a given area, while \code{clipsrc} also clips the geometries. See the
+examples and check \href{https://gdal.org/programs/ogr2ogr.html}{here} for more
+details.}
 
 \item{quiet}{Boolean. If \code{FALSE}, the function prints informative messages.
 Starting from \code{sf} version


### PR DESCRIPTION
Fix #178. For the moment I just want to test GHA (btw: @Robinlovelace I think we could simplify the GHA). Tomorrow I will add docs, tests and so on. 

Summary of the new arguments: 

``` r
# packages
library(sf)
#> Linking to GEOS 3.9.0, GDAL 3.2.1, PROJ 7.2.1
library(osmextract)
#> Data (c) OpenStreetMap contributors, ODbL 1.0. https://www.openstreetmap.org/copyright.
#> Check the package website, https://docs.ropensci.org/osmextract/, for more details.

# Leeds boundary
boundary <- osmdata::getbb("Leeds", format_out = "sf_polygon")$polygon[1, ]

# Default behaviour
par(mar = rep(0, 4))
leeds <- oe_get("Leeds, UK", boundary = boundary, vectortranslate_options = c("-where", "highway = 'primary'"))
#> No exact match found for place = Leeds, UK and provider = geofabrik. Best match is Lesotho. 
#> Checking the other providers.
#> No exact match found in any OSM provider data. Searching for the location online.
#> The input place was matched with multiple geographical areas.
#> Selecting the smallest administrative unit. Check ?oe_match for more details.
#> The chosen file was already detected in the download directory. Skip downloading.
#> Start with the vectortranslate operations on the input file!
#> 0...10...20...30...40...50...60...70...80...90...100 - done.
#> Finished the vectortranslate operations on the input file!
#> Reading layer `lines' from data source 
#>   `C:\Users\Utente\Documents\osm-data\geofabrik_west-yorkshire-latest.gpkg' 
#>   using driver `GPKG'
#> Simple feature collection with 2176 features and 9 fields
#> Geometry type: LINESTRING
#> Dimension:     XY
#> Bounding box:  xmin: -1.812148 ymin: 53.69414 xmax: -1.285605 ymax: 53.94488
#> Geodetic CRS:  WGS 84
plot(st_geometry(leeds), reset = FALSE)
plot(st_boundary(boundary), add = TRUE, col = "grey")
```

![](https://i.imgur.com/wtjcSeI.png)

``` r

# clipsrc behaviour
par(mar = rep(0, 4))
leeds <- oe_get("Leeds, UK", boundary = boundary, boundary_type = "clipsrc", vectortranslate_options = c("-where", "highway = 'primary'"))
#> No exact match found for place = Leeds, UK and provider = geofabrik. Best match is Lesotho. 
#> Checking the other providers.
#> No exact match found in any OSM provider data. Searching for the location online.
#> The input place was matched with multiple geographical areas.
#> Selecting the smallest administrative unit. Check ?oe_match for more details.
#> The chosen file was already detected in the download directory. Skip downloading.
#> Start with the vectortranslate operations on the input file!
#> 0...10...20...30...40...50...60...70...80...90...100 - done.
#> Finished the vectortranslate operations on the input file!
#> Reading layer `lines' from data source 
#>   `C:\Users\Utente\Documents\osm-data\geofabrik_west-yorkshire-latest.gpkg' 
#>   using driver `GPKG'
#> Simple feature collection with 1270 features and 9 fields
#> Geometry type: LINESTRING
#> Dimension:     XY
#> Bounding box:  xmin: -1.731322 ymin: 53.71599 xmax: -1.317923 ymax: 53.94313
#> Geodetic CRS:  WGS 84
plot(st_geometry(leeds), reset = FALSE)
plot(st_boundary(boundary), add = TRUE, col = "grey")
```

![](https://i.imgur.com/6RRq0Hb.png)

<sup>Created on 2021-05-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>
