### PR TITLE
Simplify some messages

### DIFF
--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -55,9 +55,6 @@ test_that("oe_match: different providers, match_by or max_string_dist args", {
   # case it doesn't find an exact match, so it should never return NULL
   expect_match(oe_match("Isle Wight", max_string_dist = 3, quiet = TRUE)$url, "isle-of-wight")
   expect_message(oe_match("London", max_string_dist = 3, quiet = FALSE))
-
-  # It returns a warning since Berin is matched both with Benin and Berlin
-  expect_warning(oe_match("Berin", quiet = TRUE))
 })
 
 test_that("oe_match: Cannot specify more than one place", {

--- a/vignettes/osmextract.Rmd
+++ b/vignettes/osmextract.Rmd
@@ -207,12 +207,12 @@ oe_match("Milan")
 #> [1] 416306623
 ```
 
-`oe_match()` returns a warning message if there are multiple zones equidistant (according to approximate string distance) from the input `place`. 
-In that case, it selects the first match: 
+<!-- `oe_match()` returns a warning message if there are multiple zones equidistant (according to approximate string distance) from the input `place`.  -->
+<!-- In that case, it selects the first match:  -->
 
-```{r, warning = TRUE}
-oe_match("Belin")
-```
+<!-- ```{r, warning = TRUE} -->
+<!-- oe_match("Belin") -->
+<!-- ``` -->
 
 ### Finding zones based on geographic inputs
 


### PR DESCRIPTION
Fix #204 

Example of old messages: 

``` r
library(osmextract)
#> Data (c) OpenStreetMap contributors, ODbL 1.0. https://www.openstreetmap.org/copyright.
#> Check the package website, https://docs.ropensci.org/osmextract/, for more details.
oe_match("York")
#> No exact match found for place = York and provider = geofabrik. Best match is Corse. 
#> Checking the other providers.
#> No exact match found in any OSM provider data. Searching for the location online.
#> The input place was matched with multiple geographical areas.
#> Selecting the smallest administrative unit. Check ?oe_match for more details.
#> $url
#> [1] "https://download.geofabrik.de/europe/great-britain/england/north-yorkshire-latest.osm.pbf"
#> 
#> $file_size
#> [1] 46069182
#> Warning: The input place was matched with multiple geographical zones: Corse -
#> norte - Peru - Togo. Selecting the first match.
```

<sup>Created on 2021-06-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

New approach: 

``` r
library(osmextract)
#> Data (c) OpenStreetMap contributors, ODbL 1.0. https://www.openstreetmap.org/copyright.
#> Check the package website, https://docs.ropensci.org/osmextract/, for more details.
oe_match("York")
#> No exact match found for place = York and provider = geofabrik. Best match is Corse. 
#> Checking the other providers.
#> No exact match found in any OSM provider data. Searching for the location online.
#> The input place was matched with North Yorkshire. Check the arguments in oe_match to tune the matching operations.
#> $url
#> [1] "https://download.geofabrik.de/europe/great-britain/england/north-yorkshire-latest.osm.pbf"
#> 
#> $file_size
#> [1] 46069182
```

<sup>Created on 2021-06-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

