### PR TITLE
Add new types to oe_get_network

### DIFF
--- a/R/get-network.R
+++ b/R/get-network.R
@@ -85,7 +85,7 @@
 #' plot(its_driving["highway"], lwd = 2, key.pos = 4, key.width = lcm(2.75))
 oe_get_network = function(
   place,
-  mode = c("cycling", "driving", "walking"),
+  mode = c("cycling", "driving", "walking", "cycle_infrastructure"),
   ...
 ) {
   # Load the relevant oe_get options
@@ -94,7 +94,8 @@ oe_get_network = function(
     mode,
     cycling = load_options_cycling(place),
     walking = load_options_walking(place),
-    driving = load_options_driving(place)
+    driving = load_options_driving(place),
+    cycle_infrastructure = load_options_cycle_infrastructure(place)
   )
 
   # Check the other arguments supplied by the user
@@ -216,6 +217,45 @@ load_options_driving = function(place) {
     AND
     (service IS NULL OR service NOT ILIKE 'private')
     "
+    )
+  )
+}
+
+load_options_cycle_infrastructure <- function(place) {
+  list(
+    place = place,
+    layer = "lines",
+    extra_tags = c(
+      "sidewalk_left_bicycle", "cycleway_left",
+      "cycleway_right", "cycleway", "oneway_bicycle",
+      "sidewalk_right_bicycle", "bicycle", "cycleway_both"
+    ),
+    vectortranslate_options = c(
+      "-where", "
+      sidewalk_left_bicycle = 'yes'
+      OR
+      sidewalk_right_bicycle = 'yes'
+      OR
+      cycleway_left IN ('shared_lane', 'shared_busway', 'track', 'lane')
+      OR
+      cycleway_right IN ('shared_busway', 'shared_lane', 'track', 'lane')
+      OR
+      cycleway_both = 'lane'
+      OR
+      cycleway IN ('shared_busway', 'opposite_lane', 'lane', 'track', 'opposite_track')
+      OR
+      (highway = 'bridleway' AND bicycle = 'no')
+      OR
+      bicycle = 'use_sidepath'
+      OR
+      (cycleway = 'opposite' AND oneway_bicycle = 'no')
+      OR
+      highway IN ('path', 'footway', 'cycleway')
+      OR
+      (highway = 'path' AND (bicycle = 'designated' OR bicycle = 'official'))
+      OR
+      (highway = 'pedestrian' AND (bicycle = 'yes' OR bicycle = 'official'))
+      "
     )
   )
 }

--- a/man/oe_get_network.Rd
+++ b/man/oe_get_network.Rd
@@ -4,7 +4,11 @@
 \alias{oe_get_network}
 \title{Import transport network used by a specific mode of transport}
 \usage{
-oe_get_network(place, mode = c("cycling", "driving", "walking"), ...)
+oe_get_network(
+  place,
+  mode = c("cycling", "driving", "walking", "cycle_infrastructure"),
+  ...
+)
 }
 \arguments{
 \item{place}{Description of the geographical area that should be matched with


### PR DESCRIPTION
New definitions are taken from [osminfra](https://github.com/Robinlovelace/osminfra) package. For example: 

``` r
library(osmextract)
#> Data (c) OpenStreetMap contributors, ODbL 1.0. https://www.openstreetmap.org/copyright.
#> Check the package website, https://docs.ropensci.org/osmextract/, for more details.
library(sf)
#> Linking to GEOS 3.9.0, GDAL 3.2.1, PROJ 7.2.1

iow <- oe_get_network("isle of wight", "cycle_infrastructure")
#> The input place was matched with: Isle of Wight
#> The chosen file was already detected in the download directory. Skip downloading.
#> Start with the vectortranslate operations on the input file!
#> 0...10...20...30...40...50...60...70...80...90...100 - done.
#> Finished the vectortranslate operations on the input file!
#> Reading layer `lines' from data source 
#>   `C:\Users\Utente\Documents\osm-data\geofabrik_isle-of-wight-latest.gpkg' 
#>   using driver `GPKG'
#> Simple feature collection with 6345 features and 17 fields
#> Geometry type: LINESTRING
#> Dimension:     XY
#> Bounding box:  xmin: -1.584214 ymin: 50.57523 xmax: -1.069921 ymax: 50.76732
#> Geodetic CRS:  WGS 84
plot(iow["highway"], key.length = 1, main = "", key.pos = 1)
```

![](https://i.imgur.com/g2BfX1i.png)

<sup>Created on 2021-08-24 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>


I'm not sure about all details behind those definitions, but, if you want, I can complete the PR and add all new types. 

cc @Robinlovelace and @joeytalbot