### PR TITLE
Add remove_gpkg argument

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -95,6 +95,10 @@
 #' @param download_only Boolean. If `TRUE`, then the function only returns the
 #'   path where the matched file is stored, instead of reading it. `FALSE` by
 #'   default.
+#' @param remove_gpkg Boolean. If `TRUE`, the `.gpkg` files created by
+#'   `oe_vectortranslate` are deleted after reading them. This might be useful
+#'   when using these functions in a new R package or an external server.
+#'   Default value is `FALSE`.
 #' @param ... (Named) arguments that will be passed to [`sf::st_read()`], like
 #'   `query`, `wkt_filter` or `stringsAsFactors`.  Check the introductory
 #'   vignette to understand how to create your own (SQL-like) queries.
@@ -220,6 +224,7 @@ oe_get = function(
   download_only = FALSE,
   skip_vectortranslate = FALSE,
   never_skip_vectortranslate = FALSE,
+  remove_gpkg = FALSE,
   quiet = FALSE
 ) {
 
@@ -263,6 +268,7 @@ oe_get = function(
     never_skip_vectortranslate = never_skip_vectortranslate,
     boundary = boundary,
     boundary_type = boundary_type,
+    remove_gpkg = remove_gpkg,
     quiet = quiet,
     ...
   )

--- a/R/read.R
+++ b/R/read.R
@@ -91,6 +91,7 @@ oe_read = function(
   never_skip_vectortranslate = FALSE,
   boundary = NULL,
   boundary_type = c("spat", "clipsrc"),
+  remove_gpkg = FALSE,
   quiet = FALSE
 ) {
 
@@ -327,6 +328,12 @@ oe_read = function(
   # Add another test since maybe there was an error during the vectortranslate process:
   if (!file.exists(gpkg_file_path)) {
     stop("An error occurred during the vectortranslate process", call. = FALSE)
+  }
+
+  # If remove_gpkg is TRUE, then remove the gpkg file created by oe_vectortranslate
+  if (isTRUE(remove_gpkg)) {
+    oe_message("Removing the .gpkg created by oe_vectortranslate.", quiet = quiet)
+    on.exit(unlink(gpkg_file_path))
   }
 
   # Read the translated file with sf::st_read. Moreover, starting from sf 1.0.2,

--- a/R/utils.R
+++ b/R/utils.R
@@ -47,6 +47,7 @@ oe_download_directory = function() {
 # Print a message if quiet argument is FALSE. I defined this function since the
 # same pattern is repeated several times in the package.
 oe_message <- function(..., quiet) {
+  # NB: quiet argument must always be named
   if (isFALSE(quiet)) {
     message(...)
   }

--- a/man/oe_get.Rd
+++ b/man/oe_get.Rd
@@ -24,6 +24,7 @@ oe_get(
   download_only = FALSE,
   skip_vectortranslate = FALSE,
   never_skip_vectortranslate = FALSE,
+  remove_gpkg = FALSE,
   quiet = FALSE
 )
 }
@@ -134,6 +135,11 @@ vectortranslate operations and it reads (or simply returns the path) of the
 passed its own \code{.ini} file or vectortranslate options (since, in those
 case, it's too difficult to determine if an existing \code{.gpkg} file was
 generated following the same options.)}
+
+\item{remove_gpkg}{Boolean. If \code{TRUE}, the \code{.gpkg} files created by
+\code{oe_vectortranslate} are deleted after reading them. This might be useful
+when using these functions in a new R package or an external server.
+Default value is \code{FALSE}.}
 
 \item{quiet}{Boolean. If \code{FALSE}, the function prints informative messages.
 Starting from \code{sf} version

--- a/man/oe_read.Rd
+++ b/man/oe_read.Rd
@@ -22,6 +22,7 @@ oe_read(
   never_skip_vectortranslate = FALSE,
   boundary = NULL,
   boundary_type = c("spat", "clipsrc"),
+  remove_gpkg = FALSE,
   quiet = FALSE
 )
 }
@@ -109,6 +110,11 @@ spatial filter. The \code{spat} filter selects only those features that
 intersect a given area, while \code{clipsrc} also clips the geometries. Check
 the examples and also \href{https://gdal.org/programs/ogr2ogr.html}{here} for
 more details.}
+
+\item{remove_gpkg}{Boolean. If \code{TRUE}, the \code{.gpkg} files created by
+\code{oe_vectortranslate} are deleted after reading them. This might be useful
+when using these functions in a new R package or an external server.
+Default value is \code{FALSE}.}
 
 \item{quiet}{Boolean. If \code{FALSE}, the function prints informative messages.
 Starting from \code{sf} version


### PR DESCRIPTION
First tests with remove_gpkg argument, see #235. I think that, at the moment, the only problem is that the function removes existing gpkg files. For example: 

``` r
# packages
library(osmextract)
#> Data (c) OpenStreetMap contributors, ODbL 1.0. https://www.openstreetmap.org/copyright.
#> Check the package website, https://docs.ropensci.org/osmextract/, for more details.
options("sf_max_print" = 0L)

# data
pbf_path <- system.file("its-example.osm.pbf", package = "osmextract")

# new behaviour
oe_read(pbf_path, remove_gpkg = TRUE, quiet = TRUE)
list.files(system.file(package = "osmextract"), "pbf|gpkg")
#> [1] "its-example.osm.pbf"

# default behaviour
oe_read(pbf_path, quiet = TRUE)
list.files(system.file(package = "osmextract"), "pbf|gpkg")
#> [1] "its-example.gpkg"    "its-example.osm.pbf"

# problem
oe_read(pbf_path, remove_gpkg = TRUE, quiet = TRUE)
list.files(system.file(package = "osmextract"), "pbf|gpkg")
#> [1] "its-example.osm.pbf"
```

<sup>Created on 2021-12-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


TODO: add examples and tests