### PR TITLE
Add return_pbf and return_gpkg arguments 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * The function `oe_get_keys()` gains a new argument named `download_directory` that can be used to specify the path of the directory that stores the `.osm.pbf` files. 
 * Included a new function named `oe_clean()` to remove all `.pbf` and `.gpkg` files stored in a given directory. Default value is `oe_download_directory()`. 
 * Added a message to `oe_download()` and removed a warning from `oe_read()`. The message is printed every time a user downloads a new OSM extract from a certain provider, whereas the warning used to be raised when a given `query` selected a layer different from the `layer` argument (#240). 
+* Added two new parameters to `oe_find` named `return_pbf` and `return_gpkg`. They can be used to select which file formats should the function return (#253). 
 
 ### DOCUMENTATION FIXES
 * Update description for `boundary` and `boundary_type` arguments.

--- a/R/find.R
+++ b/R/find.R
@@ -1,33 +1,42 @@
-#' Get the location of files
+#' Get the path of .pbf and .gpkg files associated with an input OSM extract
 #'
-#' This function takes a `place` name and it returns the path of `.pbf` and
-#' `.gpkg` files associated with it.
+#' This function takes a `place` name and returns the path of `.pbf`/`.gpkg`
+#' files associated with it.
 #'
-#' @details The matching between the existing files (saved in a directory
+#' @details The matching between the existing files (saved in the directory
 #'   specified by `download_directory` parameter) and the input `place` is
-#'   performed using `list.files`, setting a pattern equal to the basename of
-#'   the URL associated to the input `place`. For example, if you specify
-#'   `place = "Isle of Wight"`, then the input `place` is matched with a URL of
-#'   a `.osm.pbf` file (via [`oe_match()`]) and the matching is performed setting a
-#'   pattern equal to the basename of that URL.
+#'   performed using `list.files()`, setting the `pattern` equal to the basename
+#'   of the URL associated to the input `place`. For example, if you specify
+#'   `place = "Isle of Wight"`, then the input is matched (via [`oe_match()`])
+#'   with the URL of Isle of Wight's `.osm.pbf` file, and the files are selected
+#'   using a pattern equal to the basename of that URL.
 #'
-#'   If there is no file in `download_directory` that can be matched with the
-#'   basename and `download_if_missing` parameter is equal to `TRUE`, then the
-#'   function tries to download and translate a new file from the chosen
+#'   If there is no file in the `download_directory` that can be matched with the
+#'   basename of the URL and `download_if_missing` parameter is equal to `TRUE`, then the
+#'   function tries to download and read a new file from the chosen
 #'   provider (`geofabrik` is the default provider). If `download_if_missing`
 #'   parameter is equal to `FALSE` (default value), then the function stops with
 #'   an error.
+#'
+#'   By default, this function returns the path of `.pbf` and `.gpkg` files
+#'   associated with the input place (if any). You can exclude one of the two
+#'   formats setting the arguments `return_pbf` or `return_gpkg` to `FALSE`.
 #'
 #' @param download_directory Directory where the files downloaded by osmextract
 #'   are stored. By default it is equal to [`oe_download_directory()`].
 #' @param download_if_missing Attempt to download the file if it cannot be
 #'   found? `FALSE` by default.
+#' @param return_pbf Logical of length 1. If `TRUE`, the function returns the
+#'   path of the pbf file that matches the input `place`.
+#' @param return_gpkg Logical of length 1. If `TRUE`, the function returns the
+#'   path of the gpkg file that matches the input `place`.
 #' @param ... Extra arguments that are passed to [`oe_match()`] and [`oe_get()`].
 #'   Please note that you cannot modify the argument `download_only`.
 #' @inheritParams oe_get
 #'
 #' @return A character vector of length one (or two) representing the path(s) of the
-#'   corresponding `.pbf` (and `.gpkg`) files.
+#'   `.pbf`/`.gpkg` files associated with the input `place`.
+#'
 #' @export
 #' @examples
 #' # Copy the ITS file to tempdir() to make sure that the examples do not
@@ -41,6 +50,10 @@
 #' )
 #' res = oe_get("ITS Leeds", quiet = TRUE, download_directory = tempdir())
 #' oe_find("ITS Leeds", provider = "test", download_directory = tempdir())
+#' oe_find(
+#'   "ITS Leeds", provider = "test",
+#'   download_directory = tempdir(), return_gpkg = FALSE
+#' )
 #'
 #' \dontrun{
 #' oe_find("Isle of Wight", download_directory = tempdir())
@@ -59,14 +72,24 @@ oe_find = function(
   provider = "geofabrik",
   download_directory = oe_download_directory(),
   download_if_missing = FALSE,
+  return_pbf = TRUE,
+  return_gpkg = TRUE,
   quiet = FALSE,
   ...
   ) {
+  if (!return_gpkg && !return_pbf) {
+    stop(
+      "At least one of 'return_pbf' and 'return_gpkg' arguments must be ",
+      "equal to TRUE.",
+      call. = FALSE
+    )
+  }
+
   # I decided the approach described in @details since I cannot simply use
   # list.files(pattern = place) because the names of the files could be
-  # different from the input place.
-  # See https://github.com/ropensci/osmextract/pull/123 to check the original
-  # approach adopted with the code.
+  # different from the input place. Check
+  # https://github.com/ropensci/osmextract/pull/123 to see the approach
+  # originally adopted.
 
   # First I need to match the input place with a URL
   matched_place = oe_match(place, provider = provider, quiet = quiet, ...)
@@ -80,6 +103,14 @@ oe_find = function(
     )
   } else {
     pattern = tools::file_path_sans_ext(basename(matched_URL))
+  }
+
+  pattern <- if (return_pbf && return_gpkg) {
+    paste0(pattern, "\\.(osm\\.pbf|gpkg)$")
+  } else if (return_pbf) {
+    paste0(pattern, "\\.osm\\.pbf$")
+  } else {
+    paste0(pattern, "\\.gpkg$")
   }
 
   # Extract the files that match the pattern

--- a/R/find.R
+++ b/R/find.R
@@ -5,11 +5,11 @@
 #'
 #' @details The matching between the existing files (saved in the directory
 #'   specified by `download_directory` parameter) and the input `place` is
-#'   performed using `list.files()`, setting the `pattern` equal to the basename
-#'   of the URL associated to the input `place`. For example, if you specify
-#'   `place = "Isle of Wight"`, then the input is matched (via [`oe_match()`])
-#'   with the URL of Isle of Wight's `.osm.pbf` file, and the files are selected
-#'   using a pattern equal to the basename of that URL.
+#'   performed using `list.files()`, setting the `pattern` argument equal to the
+#'   basename of the URL associated to the input `place`. For example, if you
+#'   specify `place = "Isle of Wight"`, then the input is matched (via
+#'   [`oe_match()`]) with the URL of Isle of Wight's `.osm.pbf` file, and the
+#'   files are selected using a pattern equal to the basename of that URL.
 #'
 #'   If there is no file in the `download_directory` that can be matched with the
 #'   basename of the URL and `download_if_missing` parameter is equal to `TRUE`, then the
@@ -34,8 +34,10 @@
 #'   Please note that you cannot modify the argument `download_only`.
 #' @inheritParams oe_get
 #'
-#' @return A character vector of length one (or two) representing the path(s) of the
-#'   `.pbf`/`.gpkg` files associated with the input `place`.
+#' @return A character vector of length one (or two) representing the path(s) of
+#'   the `.pbf`/`.gpkg` files associated with the input `place`. The files are
+#'   sorted in alphabetical order which implies that if both formats are present
+#'   in the `download_directory`, then the `.gpkg` file is returned first.
 #'
 #' @export
 #' @examples
@@ -62,7 +64,8 @@
 #'   "Leeds",
 #'   provider = "bbbike",
 #'   download_if_missing = TRUE,
-#'   download_directory = tempdir()
+#'   download_directory = tempdir(),
+#'   return_pbf = FALSE
 #' )}
 #'
 #' # Remove .pbf and .gpkg files in tempdir

--- a/man/oe_find.Rd
+++ b/man/oe_find.Rd
@@ -51,8 +51,10 @@ display a progress bar.}
 Please note that you cannot modify the argument \code{download_only}.}
 }
 \value{
-A character vector of length one (or two) representing the path(s) of the
-\code{.pbf}/\code{.gpkg} files associated with the input \code{place}.
+A character vector of length one (or two) representing the path(s) of
+the \code{.pbf}/\code{.gpkg} files associated with the input \code{place}. The files are
+sorted in alphabetical order which implies that if both formats are present
+in the \code{download_directory}, then the \code{.gpkg} file is returned first.
 }
 \description{
 This function takes a \code{place} name and returns the path of \code{.pbf}/\code{.gpkg}
@@ -61,11 +63,11 @@ files associated with it.
 \details{
 The matching between the existing files (saved in the directory
 specified by \code{download_directory} parameter) and the input \code{place} is
-performed using \code{list.files()}, setting the \code{pattern} equal to the basename
-of the URL associated to the input \code{place}. For example, if you specify
-\code{place = "Isle of Wight"}, then the input is matched (via \code{\link[=oe_match]{oe_match()}})
-with the URL of Isle of Wight's \code{.osm.pbf} file, and the files are selected
-using a pattern equal to the basename of that URL.
+performed using \code{list.files()}, setting the \code{pattern} argument equal to the
+basename of the URL associated to the input \code{place}. For example, if you
+specify \code{place = "Isle of Wight"}, then the input is matched (via
+\code{\link[=oe_match]{oe_match()}}) with the URL of Isle of Wight's \code{.osm.pbf} file, and the
+files are selected using a pattern equal to the basename of that URL.
 
 If there is no file in the \code{download_directory} that can be matched with the
 basename of the URL and \code{download_if_missing} parameter is equal to \code{TRUE}, then the
@@ -102,7 +104,8 @@ oe_find(
   "Leeds",
   provider = "bbbike",
   download_if_missing = TRUE,
-  download_directory = tempdir()
+  download_directory = tempdir(),
+  return_pbf = FALSE
 )}
 
 # Remove .pbf and .gpkg files in tempdir

--- a/man/oe_find.Rd
+++ b/man/oe_find.Rd
@@ -2,13 +2,15 @@
 % Please edit documentation in R/find.R
 \name{oe_find}
 \alias{oe_find}
-\title{Get the location of files}
+\title{Get the path of .pbf and .gpkg files associated with an input OSM extract}
 \usage{
 oe_find(
   place,
   provider = "geofabrik",
   download_directory = oe_download_directory(),
   download_if_missing = FALSE,
+  return_pbf = TRUE,
+  return_gpkg = TRUE,
   quiet = FALSE,
   ...
 )
@@ -33,6 +35,12 @@ are stored. By default it is equal to \code{\link[=oe_download_directory]{oe_dow
 \item{download_if_missing}{Attempt to download the file if it cannot be
 found? \code{FALSE} by default.}
 
+\item{return_pbf}{Logical of length 1. If \code{TRUE}, the function returns the
+path of the pbf file that matches the input \code{place}.}
+
+\item{return_gpkg}{Logical of length 1. If \code{TRUE}, the function returns the
+path of the gpkg file that matches the input \code{place}.}
+
 \item{quiet}{Boolean. If \code{FALSE}, the function prints informative messages.
 Starting from \code{sf} version
 \href{https://r-spatial.github.io/sf/news/index.html#version-0-9-6-2020-09-13}{0.9.6},
@@ -44,27 +52,31 @@ Please note that you cannot modify the argument \code{download_only}.}
 }
 \value{
 A character vector of length one (or two) representing the path(s) of the
-corresponding \code{.pbf} (and \code{.gpkg}) files.
+\code{.pbf}/\code{.gpkg} files associated with the input \code{place}.
 }
 \description{
-This function takes a \code{place} name and it returns the path of \code{.pbf} and
-\code{.gpkg} files associated with it.
+This function takes a \code{place} name and returns the path of \code{.pbf}/\code{.gpkg}
+files associated with it.
 }
 \details{
-The matching between the existing files (saved in a directory
+The matching between the existing files (saved in the directory
 specified by \code{download_directory} parameter) and the input \code{place} is
-performed using \code{list.files}, setting a pattern equal to the basename of
-the URL associated to the input \code{place}. For example, if you specify
-\code{place = "Isle of Wight"}, then the input \code{place} is matched with a URL of
-a \code{.osm.pbf} file (via \code{\link[=oe_match]{oe_match()}}) and the matching is performed setting a
-pattern equal to the basename of that URL.
+performed using \code{list.files()}, setting the \code{pattern} equal to the basename
+of the URL associated to the input \code{place}. For example, if you specify
+\code{place = "Isle of Wight"}, then the input is matched (via \code{\link[=oe_match]{oe_match()}})
+with the URL of Isle of Wight's \code{.osm.pbf} file, and the files are selected
+using a pattern equal to the basename of that URL.
 
-If there is no file in \code{download_directory} that can be matched with the
-basename and \code{download_if_missing} parameter is equal to \code{TRUE}, then the
-function tries to download and translate a new file from the chosen
+If there is no file in the \code{download_directory} that can be matched with the
+basename of the URL and \code{download_if_missing} parameter is equal to \code{TRUE}, then the
+function tries to download and read a new file from the chosen
 provider (\code{geofabrik} is the default provider). If \code{download_if_missing}
 parameter is equal to \code{FALSE} (default value), then the function stops with
 an error.
+
+By default, this function returns the path of \code{.pbf} and \code{.gpkg} files
+associated with the input place (if any). You can exclude one of the two
+formats setting the arguments \code{return_pbf} or \code{return_gpkg} to \code{FALSE}.
 }
 \examples{
 # Copy the ITS file to tempdir() to make sure that the examples do not
@@ -78,6 +90,10 @@ res = file.copy(
 )
 res = oe_get("ITS Leeds", quiet = TRUE, download_directory = tempdir())
 oe_find("ITS Leeds", provider = "test", download_directory = tempdir())
+oe_find(
+  "ITS Leeds", provider = "test",
+  download_directory = tempdir(), return_gpkg = FALSE
+)
 
 \dontrun{
 oe_find("Isle of Wight", download_directory = tempdir())

--- a/tests/testthat/test-find.R
+++ b/tests/testthat/test-find.R
@@ -20,6 +20,30 @@ test_that("oe_find: simplest example works", {
   expect_length(its_leeds_find, 2)
 })
 
+test_that("oe_find: return_gpkg and return_pbf arguments work", {
+  pbf_find = oe_find(
+    "ITS Leeds",
+    download_directory = tempdir(),
+    quiet = TRUE,
+    return_gpkg = FALSE
+  )
+  gpkg_find = oe_find(
+    "ITS Leeds",
+    download_directory = tempdir(),
+    quiet = TRUE,
+    return_pbf = FALSE
+  )
+
+  expect_length(pbf_find, 1)
+  expect_length(gpkg_find, 1)
+
+  expect_type(pbf_find, "character")
+  expect_type(gpkg_find, "character")
+
+  expect_match(pbf_find, "pbf")
+  expect_match(gpkg_find, "gpkg")
+})
+
 # Clean tempdir
 oe_clean(tempdir())
 
@@ -48,3 +72,6 @@ test_that("download_if_missing in oe_find works", {
   expect_type(its_leeds_find, "character")
   expect_length(its_leeds_find, 2)
 })
+
+# Clean tempdir
+oe_clean(tempdir())


### PR DESCRIPTION
At the moment, the function `oe_find()` may return `pbf` or `gpkg` files without any particular constraint. This PR adds two new arguments named `return_pbf` and `return_gpkg` to select which format should be returned/excluded. 

