### PR TITLE
Added a more informative error message in oe_download

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -131,12 +131,25 @@ oe_download = function(
 
     oe_message("Downloading the OSM extract:", quiet = quiet)
 
-    resp = httr::GET(
-      url = file_url,
-      if (isFALSE(quiet)) httr::progress(),
-      # if (isFALSE(quiet)) httr::verbose(),
-      httr::write_disk(file_path, overwrite = TRUE),
-      httr::timeout(300L)
+    resp = tryCatch(
+      expr = {
+        httr::GET(
+          url = file_url,
+          if (isFALSE(quiet)) httr::progress(),
+          # if (isFALSE(quiet)) httr::verbose(),
+          httr::write_disk(file_path, overwrite = TRUE),
+          httr::timeout(300L)
+        )
+      },
+      error = function(e) {
+        stop(
+          "Download operation was aborted. ",
+          "We suggest you to remove the partially downloaded pbf file running the ",
+          "following code (possibly in a new R session):\n",
+          "file.remove(", dQuote(file_path, q = FALSE), ")",
+          call. = FALSE
+        )
+      }
     )
 
     httr::stop_for_status(resp, "download data from the provider")


### PR DESCRIPTION
Fix #221. I cannot always delete the partially downloaded pbf file (since it's locked on windows), so I decided to include a more informative error message: 


``` r
> oe_get("Portugal")
#> The input place was matched with: Portugal
#> Downloading the OSM extract:
#> Error: Download operation was aborted. We suggest you to remove the partially downloaded pbf file running the following code (possibly in a new R session):
#> file.remove("C:\Users\gilardi\Documents\osm-data\geofabrik_portugal-latest.osm.pbf")
```
