### PR TITLE
added `oneway` tag to driving network parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@
 
 ### MINOR CHANGES
 
-* Updated the `osmconf.ini` file to be in synch with the GDAL version. 
+* Updated the `osmconf.ini` file to be in synch with the GDAL version.
+* Added `oneway` as column by default when using `get_network(mode = "driving")`, which indicates if a link represents an uni-directional road ([#296](https://github.com/ropensci/osmextract/issues/296))
 
 # osmextract 0.5.1
 

--- a/R/get-network.R
+++ b/R/get-network.R
@@ -231,7 +231,7 @@ load_options_driving = function(place) {
   list(
     place = place,
     layer = "lines",
-    extra_tags = c("access", "service"),
+    extra_tags = c("access", "service","oneway"),
     vectortranslate_options = c(
     "-where", "
     (highway IS NOT NULL)


### PR DESCRIPTION
<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
I added an extra tag for the `load_options_driving`

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
Addresses #296 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
