### PR TITLE
Snap coordinates to OSM's native 1e-7 grid on read (#323)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -47,6 +47,11 @@ adjust_version_in_url <- function(version, url) {
 # doubles carrying sub-grid noise, which silently breaks exact matching between
 # the layers (see #323). We snap the coordinates back onto the source grid.
 snap_to_osm_grid = function(x, precision = getOption("osmextract.precision", 1e7)) {
+  # Only snap coordinates if the object is an sf object with geometry
+  if (!inherits(x, "sf")) {
+    return(x)
+  }
+  
   sf::st_set_geometry(
     x,
     sf::st_as_sfc(

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,6 +43,17 @@ adjust_version_in_url <- function(version, url) {
   gsub("latest(?=\\.osm\\.pbf$)", version, url, perl = TRUE)
 }
 
+# OSM stores coordinates on a 1e-7 precision grid. The GDAL OSM driver returns
+# doubles carrying sub-grid noise, which silently breaks exact matching between
+# the layers (see #323). We snap the coordinates back onto the source grid.
+snap_to_osm_grid = function(x, precision = getOption("osmextract.precision", 1e7)) {
+  sf::st_set_geometry(
+    x,
+    sf::st_as_sfc(
+      x = sf::st_as_binary(sf::st_geometry(x), precision = precision),
+      crs = sf::st_crs(x))
+  )
+}
 
 # Starting from sf 1.0.2, sf::st_read raises a warning message when both layer
 # and query arguments are set, while it raises a warning in sf < 1.0.2 when
@@ -51,7 +62,7 @@ adjust_version_in_url <- function(version, url) {
 # to circumvent this problem and set the appropriate arguments.
 my_st_read <- function(dsn, layer, quiet, ...) {
   dots_names = ...names()
-  if (utils::packageVersion("sf") <= "1.0.1") { # nocov start
+  out = if (utils::packageVersion("sf") <= "1.0.1") { # nocov start
     sf::st_read(
       dsn = dsn,
       layer = layer,
@@ -74,6 +85,9 @@ my_st_read <- function(dsn, layer, quiet, ...) {
       )
     }
   }
+  
+  # Snap coordinates onto OSM's native 1e-7 precision grid
+  snap_to_osm_grid(out)
 }
 
 #' Returns the download directory used by the package


### PR DESCRIPTION
## Description

This adds an internal helper, `snap_to_osm_grid`, in `R/utils.R`, and applies it to the object returned by `my_st_read`. Every layer returned by `oe_get` and `oe_read` therefore has its coordinates rounded onto OSM's native 1e-7 degree grid.

**The problem.** The GDAL OSM driver decodes the same node into slightly different doubles depending on whether it arrives via the `lines` layer or the `points` layer. The difference is in the last bits, far below OSM's own storage resolution, but it is enough to make exact matching fail silently: `st_join` misses points that lie exactly on a line, and vertices exploded with `st_coordinates` do not match the corresponding entries in the points layer. Nothing errors and nothing warns. See #323 for the full diagnosis.

**The approach.** The helper modifies the coordinates rather than setting `st_precision`. `st_precision` only sets an attribute: it is honoured by operations that pass through GEOS or GDAL and ignored by others (notably `st_coordinates`), and it is dropped by `st_transform`. Snapping means every downstream operation sees the same values, and it avoids the sfnetworks
interaction that came up when forcing `st_precision = 1e7` into `oe_read`.

**Escape hatch.** The precision reads from `getOption("osmextract.precision", 1e7)`, so the behaviour can be switched off with `options(osmextract.precision = 0)` without touching any function signature. 

**Scope and limitations.** This is a read-side fix. The `.gpkg` written by `oe_vectortranslate` is unchanged, so a file opened directly with `sf::st_read`, or inspected in QGIS, still carries the unsnapped coordinates. There might be a source-side equivalent, but I'm most confident with the R programming side.

## Related Issue

Relates to #323

## Example

Before, on the current CRAN version:

```r
library(sf)
library(dplyr)
library(osmextract)

lines  <- oe_get("ITS Leeds", layer = "lines",  quiet = TRUE) |> select(osm_id)
points <- oe_get("ITS Leeds", layer = "points", quiet = TRUE) |> select(osm_id)

nrow(lines)   #> 133
nrow(points)  #> 112

joined <- st_join(lines, points)
n_distinct(na.omit(joined$osm_id.y))   #> 6 of 112 points
```

The reason, for one of the missed points:

```r
sprintf("%.17g", c(p[1], v$X))   #> "-1.5525082000000001"  "-1.5525081999999999"
sprintf("%.17g", c(p[2], v$Y))   #> "53.808604800000005"   "53.808604799999998"
```

After, with this branch, the same code gives:

```r
n_distinct(na.omit(joined$osm_id.y))   #> 19
```

The remaining unmatched points are genuinely off the road network (they are nodes tagged with features that do not sit on any imported line), not victims of the precision mismatch.

## Tests

No tests in this PR yet.